### PR TITLE
fix(composer): use `open` instead of `openComposer`

### DIFF
--- a/javascripts/discourse/components/custom-new-topic-button.js
+++ b/javascripts/discourse/components/custom-new-topic-button.js
@@ -78,7 +78,7 @@ export default class CustomNewTopicButton extends Component {
 
   @action
   customCreateTopic() {
-    this.composer.openComposer({
+    this.composer.open({
       action: Composer.CREATE_TOPIC,
       draftKey: Composer.NEW_TOPIC_KEY,
       categoryId: this.args.category?.id,


### PR DESCRIPTION
The `openComposer` function has been deprecated as of https://github.com/discourse/discourse/pull/23015. `open` is a drop-in alternative.