### PR TITLE
FIX: action, switch category to ID, ignore replies

### DIFF
--- a/javascripts/discourse/api-initializers/customize_new_topic_text.js
+++ b/javascripts/discourse/api-initializers/customize_new_topic_text.js
@@ -11,8 +11,8 @@ const formatFilter = (filter) =>
 export default apiInitializer("0.11.1", (api) => {
   const getFilteredSetting = (model) => {
     const category = Category.findById(model._categoryId);
-    const categorySlug = category?.slug;
-    const categoryParentSlug = category?.parentCategory?.slug;
+    const categoryID = category?.id;
+    const categoryParentID = category?.parentCategory?.id;
     // not compatible with multiple tags
     // so just use the first one
     const firstTag =
@@ -30,18 +30,17 @@ export default apiInitializer("0.11.1", (api) => {
       );
     }
 
-    if (!filteredSetting && categorySlug) {
+    if (!filteredSetting && categoryID) {
       filteredSetting = parsedSetting.find(
-        (entry) => categorySlug && formatFilter(entry.filter) === categorySlug
+        (entry) => categoryID && parseInt(entry.filter, 10) === categoryID
       );
     }
 
     if (settings.inherit_parent_category) {
-      if (!filteredSetting && categoryParentSlug) {
+      if (!filteredSetting && categoryParentID) {
         filteredSetting = parsedSetting.find(
           (entry) =>
-            categoryParentSlug &&
-            formatFilter(entry.filter) === categoryParentSlug
+            categoryParentID && parseInt(entry.filter, 10) === categoryParentID
         );
       }
     }
@@ -51,14 +50,17 @@ export default apiInitializer("0.11.1", (api) => {
 
   api.customizeComposerText({
     actionTitle(model) {
-      return getFilteredSetting(model)?.composer_action_text;
+      // if the topic is present, it's a reply
+      if (!model.topic) {
+        return getFilteredSetting(model)?.composer_action_text;
+      }
     },
 
     saveLabel(model) {
       const filteredSettingText =
         getFilteredSetting(model)?.composer_button_text;
 
-      if (filteredSettingText) {
+      if (filteredSettingText && !model.topic) {
         const currentLocale = I18n.currentLocale();
 
         // a translation key is expected, so creating a temporary one here

--- a/javascripts/discourse/components/custom-new-topic-button.js
+++ b/javascripts/discourse/components/custom-new-topic-button.js
@@ -10,12 +10,7 @@ import I18n from "I18n";
 const formatFilter = (filter) =>
   filter?.toLowerCase().trim().replace(/\s+/g, "-");
 
-const settingFilter = (
-  categorySlug,
-  categoryParentSlug,
-  tagId,
-  parsedSetting
-) => {
+const settingFilter = (categoryID, categoryParentID, tagId, parsedSetting) => {
   let filteredSetting;
 
   // precedence: tag > category > parent category
@@ -26,16 +21,16 @@ const settingFilter = (
     );
   }
 
-  if (!filteredSetting && categorySlug) {
+  if (!filteredSetting && categoryID) {
     filteredSetting = parsedSetting.find(
-      (entry) => entry && formatFilter(entry.filter) === categorySlug
+      (entry) => entry && parseInt(entry.filter, 10) === categoryID
     );
   }
 
   if (settings.inherit_parent_category) {
-    if (!filteredSetting && categoryParentSlug) {
+    if (!filteredSetting && categoryParentID) {
       filteredSetting = parsedSetting.find(
-        (entry) => entry && formatFilter(entry.filter) === categoryParentSlug
+        (entry) => entry && parseInt(entry.filter) === categoryParentID
       );
     }
   }
@@ -52,16 +47,11 @@ export default class CustomNewTopicButton extends Component {
   get filteredSetting() {
     const parsedSetting = JSON.parse(settings.custom_new_topic_text);
     const category = this.args.category;
-    const categorySlug = category?.slug;
-    const categoryParentSlug = category?.parentCategory?.slug;
+    const categoryID = category?.id;
+    const categoryParentID = category?.parentCategory?.id;
     const tagId = this.args.tag?.id;
 
-    return settingFilter(
-      categorySlug,
-      categoryParentSlug,
-      tagId,
-      parsedSetting
-    );
+    return settingFilter(categoryID, categoryParentID, tagId, parsedSetting);
   }
 
   get customCreateTopicLabel() {
@@ -78,7 +68,7 @@ export default class CustomNewTopicButton extends Component {
 
   @action
   customCreateTopic() {
-    this.composer.openComposer({
+    this.composer.open({
       action: Composer.CREATE_TOPIC,
       draftKey: Composer.NEW_TOPIC_KEY,
       categoryId: this.args.category?.id,

--- a/settings.yml
+++ b/settings.yml
@@ -10,7 +10,7 @@ custom_new_topic_text:
           "filter": {
             "type": "string",
             "minLength": 1,
-            "description": "Category or tag name (note: tags take precedence)"
+            "description": "Category ID or tag name (note: tags take precedence)"
           },
           "icon": {
             "type": "string",


### PR DESCRIPTION
Fixes some issues reported here: https://meta.discourse.org/t/customize-new-topic-button-text-based-on-category-or-tag/269086/5?u=awesomerobot

1. `this.composer.openComposer` is now `this.composer.open`

2. Sometimes subcategories have the same name, so I've switched categories to use the ID instead 

3. The text for replies shouldn't be the same as for new topics, so I check if the topic is present before the switch. (future to do: allow custom reply text) 