### PR TITLE
DEV: update CSS for hiding default button

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,6 @@
-// if our connector is not empty, hide the default new topic button
-.custom-new-topic-button-connector:not(:empty) ~ #create-topic {
-  display: none;
-}
-
-.custom-new-topic-button-connector:empty {
+// hide the default new topic button
+#custom-create-topic ~ .fk-d-button-tooltip,
+#custom-create-topic ~ #create-topic {
   display: none;
 }
 


### PR DESCRIPTION
Some core changes removed the connector class, so now we can rely on the button ID directly