### PR TITLE
FIX: update this.outletArgs to @outletArgs

### DIFF
--- a/javascripts/discourse/connectors/before-create-topic-button/custom-new-topic-button-connector.hbs
+++ b/javascripts/discourse/connectors/before-create-topic-button/custom-new-topic-button-connector.hbs
@@ -1,7 +1,7 @@
 <CustomNewTopicButton
-  @category={{@category}}
-  @tag={{@tag}}
-  @createTopicLabel={{@createTopicLabel}}
-  @createTopicDisabled={{@createTopicDisabled}}
-  @canCreateTopic={{@canCreateTopic}}
+  @category={{@outletArgs.category}}
+  @tag={{@outletArgs.tag}}
+  @createTopicLabel={{@outletArgs.createTopicLabel}}
+  @createTopicDisabled={{@outletArgs.createTopicDisabled}}
+  @canCreateTopic={{@outletArgs.canCreateTopic}}
 />


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/customize-new-topic-button-text-based-on-category-or-tag/269086/18?u=arkshine

This fixes a regression from the previous PR https://github.com/discourse/discourse-customize-new-topic-button-text/commit/15954ca84422a1a4f97b4df2ab88e58fa4b1fea1 where the custom new topic button doesn't appear.  The reference to the arguments was changed from `this.args` to `@` in the connector; however, since we are in a plugin outlet context, `@outletArgs` is necessary. 

This is a quick fix. Tests would be nice; it seems the other opened PR covers them. 

