### PR TITLE
FIX: Tags need to be arrays

### DIFF
--- a/javascripts/discourse/components/custom-new-topic-button.js
+++ b/javascripts/discourse/components/custom-new-topic-button.js
@@ -46,7 +46,9 @@ export default class CustomNewTopicButton extends Component {
       action: Composer.CREATE_TOPIC,
       draftKey: Composer.NEW_TOPIC_KEY,
       categoryId: this.args.category?.id,
-      tags: this.args.tag?.id,
+      tags: Array.isArray(this.args.tag)
+      ? this.args.tag.map(tag => tag.id)
+      : this.args.tag ? [this.args.tag.id] : []
     });
   }
 }

--- a/javascripts/discourse/components/custom-new-topic-button.js
+++ b/javascripts/discourse/components/custom-new-topic-button.js
@@ -47,8 +47,10 @@ export default class CustomNewTopicButton extends Component {
       draftKey: Composer.NEW_TOPIC_KEY,
       categoryId: this.args.category?.id,
       tags: Array.isArray(this.args.tag)
-      ? this.args.tag.map(tag => tag.id)
-      : this.args.tag ? [this.args.tag.id] : []
+        ? this.args.tag.map((tag) => tag.id)
+        : this.args.tag
+          ? [this.args.tag.id]
+          : [],
     });
   }
 }


### PR DESCRIPTION
When loading tag routes like

/tags/c/aaa/79/new

and creating a new topic the tag would be added as a string instead of
an array causing a 500 error in core.
