### PR TITLE
Add Feature: Allow custom URL for New Topic button

### DIFF
--- a/javascripts/discourse/components/custom-new-topic-button.gjs
+++ b/javascripts/discourse/components/custom-new-topic-button.gjs
@@ -43,18 +43,26 @@ export default class CustomNewTopicButton extends Component {
     return this.filteredSetting?.icon;
   }
 
+  get customRedirectUrl() {
+    return this.filteredSetting?.custom_redirect_url;
+  }
+
   @action
   customCreateTopic() {
-    this.composer.open({
-      action: Composer.CREATE_TOPIC,
-      draftKey: Composer.NEW_TOPIC_KEY,
-      categoryId: this.args.category?.id,
-      tags: Array.isArray(this.args.tag)
-        ? this.args.tag.map((tag) => tag.id)
-        : this.args.tag
+    if (this.customRedirectUrl) {
+      window.location.href = this.customRedirectUrl;
+    } else {
+      this.composer.open({
+        action: Composer.CREATE_TOPIC,
+        draftKey: Composer.NEW_TOPIC_KEY,
+        categoryId: this.args.category?.id,
+        tags: Array.isArray(this.args.tag)
+          ? this.args.tag.map((tag) => tag.id)
+          : this.args.tag
           ? [this.args.tag.id]
           : [],
-    });
+      });
+    }
   }
 
   <template>

--- a/settings.yml
+++ b/settings.yml
@@ -21,6 +21,10 @@ custom_new_topic_text:
             "type": "string",
             "description": "New Topic button"
           },
+          "custom_redirect_url": {
+            "type": "string",
+            "description": "Custom URL for the New Topic button"
+          },
           "composer_action_text": {
             "type": "string",
             "description": "Composer action name (Create a new topic by default)"


### PR DESCRIPTION
Adds the ability to specify a custom URL for the New Topic button.

The classic use case is redirecting to a Custom Wizard for topic generation, but there are other situations in which this would be very helpful.

If blank, falls back to the standard behaviour.