### PR TITLE
FIX: update to support new topic button changes in core

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,14 +1,14 @@
-// 1. Hide the original "New Topic" button
+// Hide the original "New Topic" button
 #custom-create-topic ~ .d-combo-button #create-topic {
   display: none;
 }
 
-// 2. Hide the tooltip of the hidden button
+// Hide the tooltip of the hidden button
 #custom-create-topic ~ .fk-d-button-tooltip {
   display: none;
 }
 
-// 3. Make our custom button look like the left side of a combo button
+// Make our custom button look like the left side of a combo button
 // (Copying core's .d-combo-button-button styles)
 #custom-create-topic {
   border-top-right-radius: 0;
@@ -17,7 +17,7 @@
   margin-right: 0; /* Ensures it can touch the right side */
 }
 
-// 4. Force the right side (the dropdown) to pull left and match the gap
+// Force the right side (the dropdown) to pull left and match the gap
 // (Since they are siblings now, we need to override the .navigation-controls gap)
 #custom-create-topic ~ .d-combo-button {
   margin-left: -0.5em; /* Pull it left to overcome the flex gap. Adjust if necessary (usually flex gap is 0.5em) */
@@ -31,6 +31,17 @@
   border-bottom-left-radius: 0;
   border-left-color: transparent;
 }
+
+// Make sure both our custom button and the combo dropdown sit at the very right
+#custom-create-topic {
+  order: 98;
+}
+
+// Target the wrapper that holds the original button and drafts dropdown
+#custom-create-topic ~ .d-combo-button {
+  order: 99; 
+}
+
 // clean up admin json settings a little
 .json-schema-editor-modal .je-object__container .form-group {
   .form-control {

--- a/common/common.scss
+++ b/common/common.scss
@@ -23,13 +23,12 @@
   margin-left: -0.5em; /* Pull it left to overcome the flex gap. Adjust if necessary (usually flex gap is 0.5em) */
 }
 
-// Ensure the dropdown button itself still has its flat left edge
-// (It should already have this from core, but just in case it loses it because 
-// the main button is hidden, we enforce it here)
-#custom-create-topic ~ .d-combo-button .fk-d-menu__trigger {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  border-left-color: transparent;
+// Conditional styling: Only apply these when drafts dropdown (--has-menu) exists
+.navigation-controls:has(.d-combo-button.--has-menu) #custom-create-topic {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right-color: transparent;
+  margin-right: 0; 
 }
 
 // Make sure both our custom button and the combo dropdown sit at the very right

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,19 +1,19 @@
-// 1. Hide the original "New Topic" button inside the wrapper
+// Hide the original "New Topic" button inside the wrapper
 #custom-create-topic ~ .d-combo-button #create-topic {
   display: none;
 }
 
-// 2. Hide the tooltip of the hidden button
+// Hide the tooltip of the hidden button
 #custom-create-topic ~ .fk-d-button-tooltip {
   display: none;
 }
 
-// 3. Force the custom button and the dropdown wrapper to render together at the end
+// Force the custom button and the dropdown wrapper to render together at the end
 #custom-create-topic {
   order: 98;
 }
 
-// 4. Conditional styling: Only apply these when drafts dropdown (--has-menu) exists
+// Conditional styling: Only apply these when drafts dropdown (--has-menu) exists
 .navigation-controls:has(.d-combo-button.--has-menu) #custom-create-topic {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -26,7 +26,7 @@
   margin-left: -0.4em; /* Pull left to negate the flex gap */
 }
 
-// 5. Ensure the left side of the dropdown stays flat
+// Ensure the left side of the dropdown stays flat
 #custom-create-topic ~ .d-combo-button .fk-d-menu__trigger {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,29 +1,19 @@
-// Hide the original "New Topic" button
+// 1. Hide the original "New Topic" button inside the wrapper
 #custom-create-topic ~ .d-combo-button #create-topic {
   display: none;
 }
 
-// Hide the tooltip of the hidden button
+// 2. Hide the tooltip of the hidden button
 #custom-create-topic ~ .fk-d-button-tooltip {
   display: none;
 }
 
-// Make our custom button look like the left side of a combo button
-// (Copying core's .d-combo-button-button styles)
+// 3. Force the custom button and the dropdown wrapper to render together at the end
 #custom-create-topic {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-  border-right-color: transparent;
-  margin-right: 0; /* Ensures it can touch the right side */
+  order: 98;
 }
 
-// Force the right side (the dropdown) to pull left and match the gap
-// (Since they are siblings now, we need to override the .navigation-controls gap)
-#custom-create-topic ~ .d-combo-button {
-  margin-left: -0.5em; /* Pull it left to overcome the flex gap. Adjust if necessary (usually flex gap is 0.5em) */
-}
-
-// Conditional styling: Only apply these when drafts dropdown (--has-menu) exists
+// 4. Conditional styling: Only apply these when drafts dropdown (--has-menu) exists
 .navigation-controls:has(.d-combo-button.--has-menu) #custom-create-topic {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -31,14 +21,16 @@
   margin-right: 0; 
 }
 
-// Make sure both our custom button and the combo dropdown sit at the very right
-#custom-create-topic {
-  order: 98;
+.navigation-controls:has(#custom-create-topic) .d-combo-button.--has-menu {
+  order: 99; 
+  margin-left: -0.4em; /* Pull left to negate the flex gap */
 }
 
-// Target the wrapper that holds the original button and drafts dropdown
-#custom-create-topic ~ .d-combo-button {
-  order: 99; 
+// 5. Ensure the left side of the dropdown stays flat
+#custom-create-topic ~ .d-combo-button .fk-d-menu__trigger {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left-color: transparent;
 }
 
 // clean up admin json settings a little

--- a/common/common.scss
+++ b/common/common.scss
@@ -18,11 +18,11 @@
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   border-right-color: transparent;
-  margin-right: 0; 
+  margin-right: 0;
 }
 
 .navigation-controls:has(#custom-create-topic) .d-combo-button.--has-menu {
-  order: 99; 
+  order: 99;
   margin-left: -0.4em; /* Pull left to negate the flex gap */
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,9 +1,36 @@
-// hide the default new topic button
-#custom-create-topic ~ .fk-d-button-tooltip,
-#custom-create-topic ~ #create-topic {
+// 1. Hide the original "New Topic" button
+#custom-create-topic ~ .d-combo-button #create-topic {
   display: none;
 }
 
+// 2. Hide the tooltip of the hidden button
+#custom-create-topic ~ .fk-d-button-tooltip {
+  display: none;
+}
+
+// 3. Make our custom button look like the left side of a combo button
+// (Copying core's .d-combo-button-button styles)
+#custom-create-topic {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right-color: transparent;
+  margin-right: 0; /* Ensures it can touch the right side */
+}
+
+// 4. Force the right side (the dropdown) to pull left and match the gap
+// (Since they are siblings now, we need to override the .navigation-controls gap)
+#custom-create-topic ~ .d-combo-button {
+  margin-left: -0.5em; /* Pull it left to overcome the flex gap. Adjust if necessary (usually flex gap is 0.5em) */
+}
+
+// Ensure the dropdown button itself still has its flat left edge
+// (It should already have this from core, but just in case it loses it because 
+// the main button is hidden, we enforce it here)
+#custom-create-topic ~ .d-combo-button .fk-d-menu__trigger {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left-color: transparent;
+}
 // clean up admin json settings a little
 .json-schema-editor-modal .je-object__container .form-group {
   .form-control {

--- a/javascripts/discourse/components/custom-new-topic-button.gjs
+++ b/javascripts/discourse/components/custom-new-topic-button.gjs
@@ -1,3 +1,5 @@
+// This component creates a new duplicate "New Topic" button
+// which avoids modifying the existing button/translations in core
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
@@ -26,7 +28,11 @@ export default class CustomNewTopicButton extends Component {
   }
 
   get customCreateTopicLabel() {
-    return this.filteredSetting?.button_text;
+    if (this.currentUser.has_topic_draft) {
+      return i18n("topic.open_draft");
+    } else {
+      return this.filteredSetting?.button_text;
+    }
   }
 
   get customCreateTopicIcon() {
@@ -56,7 +62,7 @@ export default class CustomNewTopicButton extends Component {
           @translatedLabel={{this.customCreateTopicLabel}}
           @disabled={{@createTopicDisabled}}
           id="custom-create-topic"
-          class="btn-primary btn-icon-text" 
+          class="btn-default"
         >
           {{#if @createTopicDisabled}}
             <DTooltip>{{i18n "topic.create_disabled_category"}}</DTooltip>

--- a/javascripts/discourse/components/custom-new-topic-button.gjs
+++ b/javascripts/discourse/components/custom-new-topic-button.gjs
@@ -28,11 +28,7 @@ export default class CustomNewTopicButton extends Component {
   }
 
   get customCreateTopicLabel() {
-    if (this.currentUser.has_topic_draft) {
-      return i18n("topic.open_draft");
-    } else {
-      return this.filteredSetting?.button_text;
-    }
+    return this.filteredSetting?.button_text;
   }
 
   get customCreateTopicIcon() {
@@ -62,7 +58,7 @@ export default class CustomNewTopicButton extends Component {
           @translatedLabel={{this.customCreateTopicLabel}}
           @disabled={{@createTopicDisabled}}
           id="custom-create-topic"
-          class="btn-default"
+          class="btn-primary btn-icon-text" 
         >
           {{#if @createTopicDisabled}}
             <DTooltip>{{i18n "topic.create_disabled_category"}}</DTooltip>

--- a/javascripts/discourse/components/custom-new-topic-button.gjs
+++ b/javascripts/discourse/components/custom-new-topic-button.gjs
@@ -58,7 +58,7 @@ export default class CustomNewTopicButton extends Component {
           @translatedLabel={{this.customCreateTopicLabel}}
           @disabled={{@createTopicDisabled}}
           id="custom-create-topic"
-          class="btn-primary btn-icon-text" 
+          class="btn-default btn-icon-text"
         >
           {{#if @createTopicDisabled}}
             <DTooltip>{{i18n "topic.create_disabled_category"}}</DTooltip>

--- a/javascripts/discourse/components/custom-new-topic-button.gjs
+++ b/javascripts/discourse/components/custom-new-topic-button.gjs
@@ -1,13 +1,12 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import Composer from "discourse/models/composer";
 import { and, or } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
-import I18n from "discourse-i18n"; // Import global I18n to register keys
 import { getFilteredSetting, getTagName } from "../lib/setting-util";
-import TopicDraftsDropdown from "discourse/components/topic-drafts-dropdown";
 
 export default class CustomNewTopicButton extends Component {
   @service currentUser;
@@ -27,17 +26,7 @@ export default class CustomNewTopicButton extends Component {
   }
 
   get customCreateTopicLabel() {
-    const text = this.filteredSetting?.button_text;
-    
-    if (text) {
-      // Trick the i18n system!
-      // Dynamically register your custom text as a valid translation key.
-      const customKey = "custom_topic_button_text";
-      I18n.translations[I18n.currentLocale()].js[customKey] = text;
-      
-      // Return the new valid key!
-      return customKey;
-    }
+    return this.filteredSetting?.button_text;
   }
 
   get customCreateTopicIcon() {
@@ -67,7 +56,7 @@ export default class CustomNewTopicButton extends Component {
           @translatedLabel={{this.customCreateTopicLabel}}
           @disabled={{@createTopicDisabled}}
           id="custom-create-topic"
-          class="btn-default"
+          class="btn-primary btn-icon-text" 
         >
           {{#if @createTopicDisabled}}
             <DTooltip>{{i18n "topic.create_disabled_category"}}</DTooltip>

--- a/javascripts/discourse/components/custom-new-topic-button.gjs
+++ b/javascripts/discourse/components/custom-new-topic-button.gjs
@@ -1,14 +1,13 @@
-// This component creates a new duplicate "New Topic" button
-// which avoids modifying the existing button/translations in core
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import DButton from "discourse/components/d-button";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import Composer from "discourse/models/composer";
 import { and, or } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
+import I18n from "discourse-i18n"; // Import global I18n to register keys
 import { getFilteredSetting, getTagName } from "../lib/setting-util";
+import TopicDraftsDropdown from "discourse/components/topic-drafts-dropdown";
 
 export default class CustomNewTopicButton extends Component {
   @service currentUser;
@@ -28,10 +27,16 @@ export default class CustomNewTopicButton extends Component {
   }
 
   get customCreateTopicLabel() {
-    if (this.currentUser.has_topic_draft) {
-      return i18n("topic.open_draft");
-    } else {
-      return this.filteredSetting?.button_text;
+    const text = this.filteredSetting?.button_text;
+    
+    if (text) {
+      // Trick the i18n system!
+      // Dynamically register your custom text as a valid translation key.
+      const customKey = "custom_topic_button_text";
+      I18n.translations[I18n.currentLocale()].js[customKey] = text;
+      
+      // Return the new valid key!
+      return customKey;
     }
   }
 


### PR DESCRIPTION
this fixes the custom topic button

before:

<img width="448" height="117" alt="Screenshot" src="https://github.com/user-attachments/assets/9d7fa668-459e-4205-9ddf-9047fdfd82d5" />

after:

<img width="448" height="117" alt="Screenshot" src="https://github.com/user-attachments/assets/9d2e1fb2-a8e4-464e-adbb-bde6d190fea7" />
